### PR TITLE
fix: change forge urls under 1.12 docs to '1.12.x' from 'latest'

### DIFF
--- a/www/docs/1.12/block.md
+++ b/www/docs/1.12/block.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 In this document you learn how to do your first basic block. i.e. the simplest kind of block you can have: just a block that looks the same on all sides and does not have any other information.
 
-More in-depth information on blocks can be found at the official forge documentation: https://mcforge.readthedocs.io/en/latest/blocks/blocks/
+More in-depth information on blocks can be found at the official forge documentation: https://mcforge.readthedocs.io/en/1.12.x/blocks/blocks/
 
 ```java
 public class FirstBlock extends Block {

--- a/www/docs/1.12/config.md
+++ b/www/docs/1.12/config.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 Almost all mods need some kind of config file where players can change how your mod is balanced. Adding a config file is very easy. In this tutorial we will show you how you can do this.
 
-More explanation on the config system as well as an alternative way to do configs using annotations can be found here: https://mcforge.readthedocs.io/en/latest/config/annotations/
+More explanation on the config system as well as an alternative way to do configs using annotations can be found here: https://mcforge.readthedocs.io/en/1.12.x/config/annotations/
 
 First we add a 'Config' class that will handle our configuration. In this example it is just a single class. In bigger mods you might want to structure your configuration classes differently and perhaps group them per module. In this example we make a config file with two sections (called categories). One is for general configuration and the other is for dimension configuration (currently unused).
 

--- a/www/docs/1.12/item.md
+++ b/www/docs/1.12/item.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 In this chapter we show how to make a very basic first item.
 
-More in-depth information on items can be found at the official forge documentation: https://mcforge.readthedocs.io/en/latest/items/items/
+More in-depth information on items can be found at the official forge documentation: https://mcforge.readthedocs.io/en/1.12.x/items/items/
 
 ```java
 public class FirstItem extends Item {

--- a/www/docs/1.12/links.md
+++ b/www/docs/1.12/links.md
@@ -7,5 +7,5 @@ sidebar_position: 1
 Here are links to other sites that contain useful information related to modding on Minecraft:
 
 * [Many examples in code form. Easy to use as a start for your own blocks and items](https://github.com/TheGreyGhost/MinecraftByExample)
-* [The official Forge documentation. Very well written and good explanation on various subjects](https://mcforge.readthedocs.org/en/latest/)
+* [The official Forge documentation. Very well written and good explanation on various subjects](https://mcforge.readthedocs.org/en/1.12.x/)
 * [Another official wiki with forge documentation. Not up-to-date](https://www.minecraftforge.net/wiki/Main_Page)

--- a/www/docs/1.12/mod.md
+++ b/www/docs/1.12/mod.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 There many ways that you can structure your mod.
 This section just proposes one solution.
-The official forge documentation gives more in depth info here: https://mcforge.readthedocs.io/en/latest/gettingstarted/structuring/
+The official forge documentation gives more in depth info here: https://mcforge.readthedocs.io/en/1.12.x/gettingstarted/structuring/
 
 First here is a minimal mod class:
 

--- a/www/docs/1.12/networking.md
+++ b/www/docs/1.12/networking.md
@@ -7,7 +7,7 @@ sidebar_position: 12
 This document talks about simple networking as well as key handling.
 In this example we are going to listen to a key press on the client side (`t`) and then send a packet to the server so that the server can do some processing on it.
 
-The official Forge documentation has more detailed information on networking as well: https://mcforge.readthedocs.io/en/latest/networking/
+The official Forge documentation has more detailed information on networking as well: https://mcforge.readthedocs.io/en/1.12.x/networking/
 
 First we need to register our key bindings.
 This can be done like this. This code basically registers a new key and assigns it to `t` by default.

--- a/www/docs/1.12/recipe.md
+++ b/www/docs/1.12/recipe.md
@@ -8,7 +8,7 @@ The recipe system has changed a lot in 1.12.
 This is not a complete tutorial but should show you a few basics.
 The information here is not yet included in the ModTut GitHub and needs to be worked out more.
 
-More information on recipes can be found at the official forge documentation: https://mcforge.readthedocs.io/en/latest/utilities/recipes/
+More information on recipes can be found at the official forge documentation: https://mcforge.readthedocs.io/en/1.12.x/utilities/recipes/
 
 Recipes are now handled through JSON. Here is how you can define a simple recipe (no code changes are required).
 Simply place this JSON (name doesn't matter) in `assets/modname/recipes`, and it will work:

--- a/www/docs/1.12/rendering/rendering.md
+++ b/www/docs/1.12/rendering/rendering.md
@@ -7,7 +7,7 @@ sidebar_position: 11
 In the earlier tutorials you saw how to make a basic block and item, but it looked very ugly.
 In this chapter we will demonstrate various techniques available to you for making your items and blocks look nice.
 
-The official Forge documentation has a lot of detailed information on models so beyond the examples given in this chapter be sure to read that too: https://mcforge.readthedocs.io/en/latest/models/introduction/
+The official Forge documentation has a lot of detailed information on models so beyond the examples given in this chapter be sure to read that too: https://mcforge.readthedocs.io/en/1.12.x/models/introduction/
 
 * [Rendering of a basic item](./item.md)
 * [Rendering of an item based on NBT or damage](./item-nbt.md)

--- a/www/docs/1.12/tile-entity/tile-entity.md
+++ b/www/docs/1.12/tile-entity/tile-entity.md
@@ -7,7 +7,7 @@ sidebar_position: 7
 If you want to add extra data to your block (more than what you can fit in the 4 bits of metadata) or you want to add some kind of logic to the block (i.e. it is a machine or other device) then you need a tile entity.
 In this chapter we show a few example tile entities.
 
-More in-depth information on tile entities can be found at the official forge documentation: https://mcforge.readthedocs.io/en/latest/tileentities/tileentity/
+More in-depth information on tile entities can be found at the official forge documentation: https://mcforge.readthedocs.io/en/1.12.x/tileentities/tileentity/
 
 * [Using a tile entity to store some data](./data.md)
 * [Using a tile entity that does some timed action](./lights.md)


### PR DESCRIPTION
mcforge.readthedocs.io/lang/latest points to the latest version of forge's documentation.

This is fine for docs regarding the latest forge version, but not for docs regarding old forge versions.

The docs for forge 1.12.x are still live, just unlisted. Replacing 'latest' with '1.12.x' ensures that viewers of the 1.12.x docs are directed to the forge docs for the corresponding version.

- [X] replacements for 1.12
- [ ] replacements for other non-latest versions